### PR TITLE
Fix Sized error in broken test

### DIFF
--- a/tests/rustc-issue-25394.rs
+++ b/tests/rustc-issue-25394.rs
@@ -15,7 +15,7 @@ extern crate derivative;
 #[derivative(Debug)]
 struct Row<T>([T]);
 
-fn use_row(_: Row<u8>) {}
+fn use_row(_: &Row<u8>) {}
 
 #[test]
 fn main() {


### PR DESCRIPTION
A function was using `_: Row<u8>` as an argument, where Row is not
Sized; fix the type of the function.

Fixes the issue in rust-lang/rust#43663