### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 target
 Cargo.lock
+*.rs.bk
+[._]*.sw?
+[._]sw?
+*~
 /_book
 /node_modules

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,9 @@ appveyor = { repository = "mcarton/rust-derivative" }
 proc-macro = true
 
 [dependencies]
-itertools = "~0.5"
-quote = "^0.3"
-syn = { version = "0.10", features = ["aster", "full", "visit"] }
-compiletest_rs = { version = "^0.2", optional = true }
+quote = "0.5"
+syn = { version = "0.13", features = ["extra-traits", "full", "visit"] }
+compiletest_rs = { version = "0.3", optional = true }
 
 [features]
 nightly = ["compiletest_rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 
 [dependencies]
 quote = "0.5"
-syn = { version = "0.13", features = ["extra-traits", "full", "visit"] }
+syn = { version = "0.13.1", features = ["extra-traits", "full", "visit"] }
 compiletest_rs = { version = "0.3", optional = true }
 
 [features]

--- a/src/bound.rs
+++ b/src/bound.rs
@@ -13,19 +13,26 @@
 use ast;
 use attr;
 use std::collections::HashSet;
-use syn::{self, aster, visit};
-
-// use internals::ast::Item;
-// use internals::attr;
+use syn;
 
 /// Remove the default from every type parameter because in the generated `impl`s
 /// they look like associated types: "error: associated type bindings are not
 /// allowed here".
 pub fn without_defaults(generics: &syn::Generics) -> syn::Generics {
     syn::Generics {
-        ty_params: generics.ty_params
+        params: generics.params
             .iter()
-            .map(|ty_param| syn::TyParam { default: None, ..ty_param.clone() })
+            .map(|param| {
+                match *param {
+                    syn::GenericParam::Type(ref type_param) => {
+                        syn::GenericParam::Type(syn::TypeParam {
+                            default: None,
+                            ..type_param.clone()
+                        })
+                    }
+                    ref other => other.clone(),
+                }
+            })
             .collect(),
         ..generics.clone()
     }
@@ -35,9 +42,27 @@ pub fn with_where_predicates(
     generics: &syn::Generics,
     predicates: &[syn::WherePredicate],
 ) -> syn::Generics {
-    aster::from_generics(generics.clone())
-        .with_predicates(predicates.to_vec())
-        .build()
+    let predicates = predicates.iter().cloned();
+
+    syn::Generics {
+        where_clause: Some(
+            match generics.where_clause {
+                Some(ref where_clause) => {
+                    syn::WhereClause {
+                        where_token: where_clause.where_token,
+                        predicates: where_clause.predicates.iter().cloned().chain(predicates).collect(),
+                    }
+                }
+                None => {
+                    syn::WhereClause {
+                        where_token: <Token![where]>::default(),
+                        predicates: predicates.collect(),
+                    }
+                }
+            }
+        ),
+        ..generics.clone()
+    }
 }
 
 pub fn with_where_predicates_from_fields<F>(
@@ -47,14 +72,32 @@ pub fn with_where_predicates_from_fields<F>(
 ) -> syn::Generics
     where F: Fn(&attr::Field) -> Option<&[syn::WherePredicate]>,
 {
-    aster::from_generics(generics.clone())
-        .with_predicates(
-            item.body
-                .all_fields()
-                .iter()
-                .flat_map(|field| from_field(&field.attrs))
-                .flat_map(|predicates| predicates.to_vec()))
-        .build()
+    let all_fields = item.data.all_fields();
+    let predicates = all_fields
+        .iter()
+        .flat_map(|field| from_field(&field.attrs))
+        .flat_map(|predicates| predicates.iter())
+        .cloned();
+
+    syn::Generics {
+        where_clause: Some(
+            match generics.where_clause {
+                Some(ref where_clause) => {
+                    syn::WhereClause {
+                        where_token: where_clause.where_token,
+                        predicates: where_clause.predicates.iter().cloned().chain(predicates).collect(),
+                    }
+                }
+                None => {
+                    syn::WhereClause {
+                        where_token: <Token![where]>::default(),
+                        predicates: predicates.collect(),
+                    }
+                }
+            }
+        ),
+        ..generics.clone()
+    }
 }
 
 /// Puts the given bound on any generic type parameters that are used in fields
@@ -79,65 +122,82 @@ pub fn with_bound<F>(
     where F: Fn(&attr::Field) -> bool,
 {
     #[derive(Debug)]
-    struct FindTyParams {
+    struct FindTypeParams {
         /// Set of all generic type parameters on the current struct (A, B, C in
         /// the example). Initialized up front.
-        all_ty_params: HashSet<syn::Ident>,
+        all_type_params: HashSet<syn::Ident>,
         /// Set of generic type parameters used in fields for which filter
         /// returns true (A and B in the example). Filled in as the visitor sees
         /// them.
-        relevant_ty_params: HashSet<syn::Ident>,
+        relevant_type_params: HashSet<syn::Ident>,
     }
-    impl visit::Visitor for FindTyParams {
-        fn visit_path(&mut self, path: &syn::Path) {
-            if let Some(seg) = path.segments.last() {
+
+    impl<'ast> syn::visit::Visit<'ast> for FindTypeParams {
+        fn visit_path(&mut self, path: &'ast syn::Path) {
+            if let Some(seg) = path.segments.last().map(|pair| pair.into_value()) {
                 if seg.ident == "PhantomData" {
                     // Hardcoded exception, because `PhantomData<T>` implements
                     // most traits whether or not `T` implements it.
                     return;
                 }
             }
-            if !path.global && path.segments.len() == 1 {
-                let id = path.segments[0].ident.clone();
-                if self.all_ty_params.contains(&id) {
-                    self.relevant_ty_params.insert(id);
+
+            if !path.global() && path.segments.len() == 1 {
+                let id = path.segments[0].ident;
+                if self.all_type_params.contains(&id) {
+                    self.relevant_type_params.insert(id);
                 }
             }
-            visit::walk_path(self, path);
+
+            syn::visit::visit_path(self, path);
         }
     }
 
-    let all_ty_params: HashSet<_> = generics.ty_params
-        .iter()
-        .map(|ty_param| ty_param.ident.clone())
+    let all_type_params: HashSet<_> = generics.type_params()
+        .map(|type_param| type_param.ident)
         .collect();
 
-    let relevant_tys = item.body
+    let relevant_types = item.data
         .all_fields()
         .into_iter()
         .filter(|field| filter(&field.attrs))
-        .map(|field| &field.ty);
+        .map(|field| &field.type_);
 
-    let mut visitor = FindTyParams {
-        all_ty_params: all_ty_params,
-        relevant_ty_params: HashSet::new(),
+    let mut visitor = FindTypeParams {
+        all_type_params: all_type_params,
+        relevant_type_params: HashSet::new(),
     };
-    for ty in relevant_tys {
-        visit::walk_ty(&mut visitor, ty);
+
+    for type_ in relevant_types {
+        syn::visit::visit_type(&mut visitor, type_);
     }
 
-    aster::from_generics(generics.clone())
-        .with_predicates(generics.ty_params
-            .iter()
-            .map(|ty_param| ty_param.ident.clone())
-            .filter(|id| visitor.relevant_ty_params.contains(id))
-            .map(|id| {
-                aster::where_predicate()
-                    // the type parameter that is being bounded e.g. `T`
-                    .bound().build(aster::ty().id(id))
-                    // the bound e.g. `Debug`
-                    .bound().trait_(bound.clone()).build()
-                    .build()
-            }))
-        .build()
+    let predicates = generics.type_params()
+        .map(|type_param| type_param.ident)
+        .filter(|id| visitor.relevant_type_params.contains(id))
+        .map(|id| {
+            parse_quote! {
+                #id: #bound
+            }
+        });
+
+    syn::Generics {
+        where_clause: Some(
+            match generics.where_clause {
+                Some(ref where_clause) => {
+                    syn::WhereClause {
+                        where_token: where_clause.where_token,
+                        predicates: where_clause.predicates.iter().cloned().chain(predicates).collect(),
+                    }
+                }
+                None => {
+                    syn::WhereClause {
+                        where_token: <Token![where]>::default(),
+                        predicates: predicates.collect(),
+                    }
+                }
+            }
+        ),
+        ..generics.clone()
+    }
 }

--- a/src/default.rs
+++ b/src/default.rs
@@ -1,7 +1,7 @@
 use ast;
 use attr;
 use quote;
-use syn::{self, aster};
+use syn;
 use utils;
 
 /// Derive `Default` for `input`.
@@ -13,41 +13,46 @@ pub fn derive(input: &ast::Input, default: &attr::InputDefault) -> quote::Tokens
     ) -> quote::Tokens {
         match style {
             ast::Style::Struct => {
-                let mut defaults = Vec::new();
+                let defaults = fields
+                    .iter()
+                    .map(|f| {
+                        let name = f.ident.as_ref().expect("A structure field must have a name");
+                        let default = f.attrs.default_value().map_or_else(
+                            || quote!(::std::default::Default::default()),
+                            |v| quote!(#v),
+                        );
 
-                for f in fields {
-                    let name = f.ident.as_ref().expect("A structure field must have a name");
-                    let default = f.attrs.default_value().map_or_else(
-                        || quote!(::std::default::Default::default()),
-                        |v| quote!(#v),
-                    );
+                        quote!(#name: #default)
+                    });
 
-                    defaults.push(quote!(#name: #default));
+                quote! {
+                    #variant_name {
+                        #(#defaults,)*
+                    }
                 }
-
-                quote!(#variant_name { #(#defaults),* })
             }
             ast::Style::Tuple => {
-                let mut defaults = Vec::new();
+                let defaults = fields
+                    .iter()
+                    .map(|f| {
+                        f.attrs.default_value().map_or_else(
+                            || quote!(::std::default::Default::default()),
+                            |v| quote!(#v),
+                        )
+                    });
 
-                for f in fields {
-                    let default = f.attrs.default_value().map_or_else(
-                        || quote!(::std::default::Default::default()),
-                        |v| quote!(#v),
-                    );
-
-                    defaults.push(default);
+                quote! {
+                    #variant_name ( #(#defaults,)* )
                 }
-
-                quote!(#variant_name ( #(#defaults),* ))
             }
             ast::Style::Unit => quote!(#variant_name),
         }
     }
 
-    let name = &input.ident;
+    let name = input.ident;
     let default_trait_path = default_trait_path();
-    let impl_generics = utils::build_impl_generics(
+
+    let (impl_generics, path_args) = utils::build_generics(
         input,
         &default_trait_path,
         |attrs| attrs.default_bound().is_none(),
@@ -56,18 +61,19 @@ pub fn derive(input: &ast::Input, default: &attr::InputDefault) -> quote::Tokens
     );
     let where_clause = &impl_generics.where_clause;
 
-    let ty = syn::aster::ty()
-        .path()
-        .segment(name.clone())
-        .with_generics(impl_generics.clone())
-        .build()
-        .build();
+    let type_ = syn::Type::Path(syn::TypePath {
+        qself: None,
+        path: syn::PathSegment {
+            ident: name,
+            arguments: path_args,
+        }.into(),
+    });
 
-    let body = match input.body {
-        ast::Body::Enum(ref data) => {
-            let arms = data.iter().filter_map(|variant| {
+    let body = match input.data {
+        ast::Data::Enum(ref variants) => {
+            let arms = variants.iter().filter_map(|variant| {
                 if variant.attrs.default.is_some() {
-                    let vname = &variant.ident;
+                    let vname = variant.ident;
 
                     Some(make_variant_data(quote!(#name::#vname), variant.style, &variant.fields))
                 } else {
@@ -77,39 +83,37 @@ pub fn derive(input: &ast::Input, default: &attr::InputDefault) -> quote::Tokens
 
             quote!(#(#arms),*)
         }
-        ast::Body::Struct(style, ref vd) => {
-            make_variant_data(quote!(#name), style, vd)
+        ast::Data::Struct(style, ref fields) => {
+            make_variant_data(quote!(#name), style, fields)
         }
     };
 
     let new_fn = if default.new {
-        Some(quote!(
-            #[allow(unused_qualifications)]
-            impl #impl_generics #ty #where_clause {
+        Some(quote! {
+            impl #impl_generics #type_ #where_clause {
                 /// Creates a default value for this type.
                 #[inline]
                 pub fn new() -> Self {
                     #default_trait_path::default()
                 }
             }
-        ))
+        })
     } else {
         None
     };
 
-    quote!(
+    quote! {
         #new_fn
 
-        #[allow(unused_qualifications)]
-        impl #impl_generics #default_trait_path for #ty #where_clause {
+        impl #impl_generics #default_trait_path for #type_ #where_clause {
             fn default() -> Self {
                 #body
             }
         }
-    )
+    }
 }
 
 /// Return the path of the `Default` trait, that is `::std::default::Default`.
 fn default_trait_path() -> syn::Path {
-    aster::path().global().ids(&["std", "default", "Default"]).build()
+    parse_quote! { ::std::default::Default }
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -81,10 +81,10 @@ fn needs_hash_bound(attrs: &attr::Field) -> bool {
     !attrs.ignore_hash() && attrs.hash_bound().is_none()
 }
 
-fn hasher_trait_path() -> syn::Path {
-    parse_quote! { ::std::hash::Hasher }
-}
-
 fn hash_trait_path() -> syn::Path {
     parse_quote! { ::std::hash::Hash }
+}
+
+fn hasher_trait_path() -> syn::Path {
+    parse_quote! { ::std::hash::Hasher }
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -2,21 +2,28 @@ use ast;
 use attr;
 use matcher;
 use quote;
-use syn::{self, aster};
+use syn;
 use utils;
 
 pub fn derive(input: &ast::Input) -> quote::Tokens {
-    let hasher_trait_path = hasher_trait_path();
     let hash_trait_path = hash_trait_path();
 
     let body = matcher::Matcher::new(matcher::BindingStyle::Ref)
         .build_arms(input, |arm_path, _, _, _, bis| {
+            let variant = if let ast::Data::Enum(_) = input.data {
+                Some(quote! {
+                    #hash_trait_path::hash(&(#arm_path as u64), __state);
+                })
+            } else {
+                None
+            };
+
             let field_prints = bis.iter().filter_map(|bi| {
                 if bi.field.attrs.ignore_hash() {
                     return None;
                 }
 
-                let arg = &bi.ident;
+                let arg = bi.ident;
 
                 if let Some(hash_with) = bi.field.attrs.hash_with() {
                     Some(quote! {
@@ -29,23 +36,16 @@ pub fn derive(input: &ast::Input) -> quote::Tokens {
                 }
             });
 
-            let variant = if let ast::Body::Enum(_) = input.body {
-                Some(quote!(
-                    #hash_trait_path::hash(&(#arm_path as u64), __state);
-                ))
-            } else {
-                None
-            };
-
             quote! {
                 #variant
                 #(#field_prints)*
             }
         });
 
-    let name = &input.ident;
+    let name = input.ident;
+    let hasher_trait_path = hasher_trait_path();
 
-    let impl_generics = utils::build_impl_generics(
+    let (impl_generics, path_args) = utils::build_generics(
         input,
         &hash_trait_path,
         needs_hash_bound,
@@ -54,19 +54,20 @@ pub fn derive(input: &ast::Input) -> quote::Tokens {
     );
     let where_clause = &impl_generics.where_clause;
 
-    let ty = syn::aster::ty()
-        .path()
-        .segment(name.clone())
-        .with_generics(impl_generics.clone())
-        .build()
-        .build();
+    let type_ = syn::Type::Path(syn::TypePath {
+        qself: None,
+        path: syn::PathSegment {
+            ident: name,
+            arguments: path_args,
+        }.into(),
+    });
 
-    let hasher_ty_parameter = utils::hygienic_type_parameter(input, "__H");
+    let hasher_type_parameter = utils::hygienic_type_parameter(input, "__H");
+
     quote! {
-        #[allow(unused_qualifications)]
-        impl #impl_generics #hash_trait_path for #ty #where_clause {
-            fn hash<#hasher_ty_parameter>(&self, __state: &mut #hasher_ty_parameter)
-                where #hasher_ty_parameter: #hasher_trait_path
+        impl #impl_generics #hash_trait_path for #type_ #where_clause {
+            fn hash<#hasher_type_parameter>(&self, __state: &mut #hasher_type_parameter)
+                where #hasher_type_parameter: #hasher_trait_path
             {
                 match *self {
                     #body
@@ -80,12 +81,10 @@ fn needs_hash_bound(attrs: &attr::Field) -> bool {
     !attrs.ignore_hash() && attrs.hash_bound().is_none()
 }
 
-/// Return the path of the `Hash` trait, that is `::std::hash::Hash`.
-fn hash_trait_path() -> syn::Path {
-    aster::path().global().ids(&["std", "hash", "Hash"]).build()
+fn hasher_trait_path() -> syn::Path {
+    parse_quote! { ::std::hash::Hasher }
 }
 
-/// Return the path of the `Hasher` trait, that is `::std::hash::Hasher`.
-fn hasher_trait_path() -> syn::Path {
-    aster::path().global().ids(&["std", "hash", "Hasher"]).build()
+fn hash_trait_path() -> syn::Path {
+    parse_quote! { ::std::hash::Hash }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate proc_macro;
-extern crate syn;
-
 #[macro_use]
 extern crate quote;
+#[macro_use]
+extern crate syn;
 
 mod ast;
 mod attr;
@@ -17,29 +17,29 @@ mod utils;
 
 use proc_macro::TokenStream;
 
-fn derive_impls(input: &ast::Input) -> Result<quote::Tokens, String> {
+fn derive_impls(input: ast::Input) -> Result<quote::Tokens, String> {
     let mut tokens = quote::Tokens::new();
 
     if input.attrs.clone.is_some() {
-        tokens.append(&clone::derive_clone(input).to_string());
+        tokens.append_all(clone::derive_clone(&input));
     }
     if input.attrs.copy.is_some() {
-        tokens.append(&try!(clone::derive_copy(input)).to_string());
+        tokens.append_all(clone::derive_copy(&input)?);
     }
     if input.attrs.debug.is_some() {
-        tokens.append(&debug::derive(input).to_string());
+        tokens.append_all(debug::derive(&input));
     }
     if let Some(ref default) = input.attrs.default {
-        tokens.append(&default::derive(input, default).to_string());
+        tokens.append_all(default::derive(&input, default));
     }
     if input.attrs.eq.is_some() {
-        tokens.append(&cmp::derive_eq(input).to_string());
+        tokens.append_all(cmp::derive_eq(&input));
     }
     if input.attrs.hash.is_some() {
-        tokens.append(&hash::derive(input).to_string());
+        tokens.append_all(hash::derive(&input));
     }
     if input.attrs.partial_eq.is_some() {
-        tokens.append(&try!(cmp::derive_partial_eq(input)).to_string());
+        tokens.append_all(cmp::derive_partial_eq(&input)?);
     }
 
     Ok(tokens)
@@ -48,10 +48,10 @@ fn derive_impls(input: &ast::Input) -> Result<quote::Tokens, String> {
 #[cfg_attr(not(test), proc_macro_derive(Derivative, attributes(derivative)))]
 pub fn derivative(input: TokenStream) -> TokenStream {
     fn detail(input: TokenStream) -> Result<TokenStream, String> {
-        let input = try!(syn::parse_macro_input(&input.to_string()));
-        let parsed = try!(ast::Input::from_ast(&input));
-        let output = try!(derive_impls(&parsed));
-        Ok(output.to_string().parse().unwrap())
+        let input = syn::parse(input).map_err(|e| e.to_string())?;
+        let parsed = ast::Input::from_ast(&input)?;
+        let output = derive_impls(parsed)?;
+        Ok(output.into())
     }
 
     match detail(input) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,13 +5,13 @@ use syn;
 
 /// Make generic with all the generics in the input, plus a bound `T: <trait_path>` for each
 /// generic field type that will be shown.
-pub fn build_impl_generics<F, G, H>(
+pub fn build_generics<F, G, H>(
     item: &ast::Input,
     trait_path: &syn::Path,
     needs_debug_bound: F,
     field_bound: G,
     input_bound: H,
-) -> syn::Generics
+) -> (syn::Generics, syn::PathArguments)
     where F: Fn(&attr::Field) -> bool,
           G: Fn(&attr::Field) -> Option<&[syn::WherePredicate]>,
           H: Fn(&attr::Input) -> Option<&[syn::WherePredicate]>,
@@ -21,25 +21,60 @@ pub fn build_impl_generics<F, G, H>(
         item, &generics, field_bound
     );
 
-    match input_bound(&item.attrs) {
+    let impl_generics = match input_bound(&item.attrs) {
         Some(predicates) => {
             bound::with_where_predicates(&generics, predicates)
         }
         None => {
             bound::with_bound(item, &generics, needs_debug_bound, trait_path)
         }
-    }
+    };
+
+    let path_args = if impl_generics.params.is_empty() {
+        syn::PathArguments::None
+    } else {
+        let generic_args = impl_generics.params
+            .iter()
+            .map(|param| {
+                match *param {
+                    syn::GenericParam::Type(syn::TypeParam { ident, .. }) => {
+                        syn::GenericArgument::Type(syn::Type::Path(syn::TypePath {
+                            qself: None,
+                            path: ident.into(),
+                        }))
+                    }
+                    syn::GenericParam::Lifetime(syn::LifetimeDef { lifetime, .. }) => {
+                        syn::GenericArgument::Lifetime(lifetime)
+                    }
+                    syn::GenericParam::Const(_) => {
+                        // TODO: yet?
+                        unimplemented!();
+                    }
+                }
+            })
+            .collect();
+
+        syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
+            colon2_token: None,
+            lt_token: <Token![<]>::default(),
+            args: generic_args,
+            gt_token: <Token![>]>::default(),
+        })
+    };
+
+    (impl_generics, path_args)
 }
 
+// TODO: this function should be obsolete with `Span::def_site()` when it stabilizes
 /// Construct a name for the inner type parameter that can't collide with any
 /// type parameters of the item. This is achieved by starting with a base and
 /// then concatenating the names of all other type parameters.
 pub fn hygienic_type_parameter(item: &ast::Input, base: &str) -> syn::Ident {
-    let mut typaram = String::from(base);
+    let mut string_type_param = base.to_string();
 
-    for ty in &item.generics.ty_params {
-        typaram.push_str(&ty.ident.as_ref());
+    for param in item.generics.type_params() {
+        string_type_param.push_str(param.ident.as_ref());
     }
 
-    syn::Ident::new(typaram)
+    syn::Ident::from(string_type_param)
 }

--- a/tests/compile-fail/derive-partial-eq.rs
+++ b/tests/compile-fail/derive-partial-eq.rs
@@ -2,7 +2,7 @@
 extern crate derivative;
 
 #[derive(Derivative)]
-//~^ ERROR custom derive attribute panicked
+//~^ ERROR proc-macro derive panicked
 //~| HELP can't use `#[derivative(PartialEq)]` on an enumeration without `feature_allow_slow_enum`
 #[derivative(PartialEq)]
 enum Option<T> {

--- a/tests/compile-test.rs
+++ b/tests/compile-test.rs
@@ -6,7 +6,8 @@ fn run_mode(dir: &'static str, mode: &'static str) {
     use std::path::PathBuf;
     use std::env::var;
 
-    let mut config = compiletest::default_config();
+    //let mut config = compiletest::default_config();
+    let mut config = compiletest::Config::default();
 
     let cfg_mode = mode.parse().expect("Invalid mode");
     config.target_rustcflags = Some("-L target/debug/ -L target/debug/deps".to_owned());


### PR DESCRIPTION
More specifically:
- `syn` 0.10 -> 0.13 which required a significant amount of changes;
- `quote` 0.3 -> 0.5 -- nearly no changes at all;
- `compiletest_rs` 0.2 -> 0.3 so that compile-fail tests could run on the latest nightly;
- `itertools` has been removed because it wasn't used even before the update (I guess it was missed during refactoring before).

The `derive-copy-clone` compile-fail test should fail on Rust 1.17+ because it compiles successfully due to https://github.com/rust-lang/rust/pull/39572. I'll remove the test after this PR gets merged.