### PR TITLE
Include README.md in Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "derivative"
 version = "1.0.2"
 authors = ["mcarton <cartonmartin+git@gmail.com>"]
 license = "MIT/Apache-2.0"
+readme = "README.md"
 documentation = "https://mcarton.github.io/rust-derivative/"
 repository = "https://github.com/mcarton/rust-derivative"
 description = "A set of alternative `derive` attributes for Rust"


### PR DESCRIPTION
With this, users wouldn't have to go to repo to see README, the crates.io page for the crate is enough.