### PR TITLE
Work around `overflow evaluating the requirement` in Nightly rustdoc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derivative"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["mcarton <cartonmartin+git@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@
     redundant_field_names,
 ))]
 
+// https://github.com/rust-lang/rust/issues/62132
+#![recursion_limit="128"]
+
 extern crate proc_macro;
 extern crate proc_macro2;
 #[macro_use]


### PR DESCRIPTION
In current Nightly, `cargo doc` fails with the error message below. The fix in rustdoc is at the “investigating the feasibility” stage.

See https://github.com/rust-lang/rust/issues/62132 and https://github.com/rust-lang/rust/issues/62059

```rust
error[E0275]: overflow evaluating the requirement `proc_macro2::Group: std::marker::Unpin`
  |
  = help: consider adding a `#![recursion_limit="128"]` attribute to your crate
  = note: required because it appears within the type `proc_macro2::TokenTree`
  = note: required because it appears within the type `*const proc_macro2::TokenTree`
  = note: required because it appears within the type `std::ptr::Unique<proc_macro2::TokenTree>`
  = note: required because it appears within the type `alloc::raw_vec::RawVec<proc_macro2::TokenTree>`
  = note: required because it appears within the type `std::vec::Vec<proc_macro2::TokenTree>`
  = note: required because it appears within the type `proc_macro2::fallback::TokenStream`
  = note: required because it appears within the type `proc_macro2::imp::TokenStream`
  = note: required because it appears within the type `proc_macro2::TokenStream`
  = note: required because it appears within the type `syn::Macro`
  = note: required because it appears within the type `syn::PatMacro`
  = note: required because it appears within the type `syn::Pat`
  = note: required because it appears within the type `(syn::Pat, syn::token::Or)`
  = note: required because it appears within the type `*const (syn::Pat, syn::token::Or)`
  = note: required because it appears within the type `std::ptr::Unique<(syn::Pat, syn::token::Or)>`
  = note: required because it appears within the type `alloc::raw_vec::RawVec<(syn::Pat, syn::token::Or)>`
  = note: required because it appears within the type `std::vec::Vec<(syn::Pat, syn::token::Or)>`
  = note: required because it appears within the type `syn::punctuated::Punctuated<syn::Pat, syn::token::Or>`
  = note: required because it appears within the type `syn::ExprLet`
  = note: required because it appears within the type `syn::Expr`
  = note: required because it appears within the type `syn::TypeArray`
  = note: required because it appears within the type `syn::Type`
  = note: required because it appears within the type `syn::GenericArgument`
  = note: required because it appears within the type `(syn::GenericArgument, syn::token::Comma)`
  = note: required because it appears within the type `*const (syn::GenericArgument, syn::token::Comma)`
  = note: required because it appears within the type `std::ptr::Unique<(syn::GenericArgument, syn::token::Comma)>`
  = note: required because it appears within the type `alloc::raw_vec::RawVec<(syn::GenericArgument, syn::token::Comma)>`
  = note: required because it appears within the type `std::vec::Vec<(syn::GenericArgument, syn::token::Comma)>`
  = note: required because it appears within the type `syn::punctuated::Punctuated<syn::GenericArgument, syn::token::Comma>`
  = note: required because it appears within the type `syn::AngleBracketedGenericArguments`
  = note: required because it appears within the type `syn::PathArguments`
  = note: required because it appears within the type `syn::PathSegment`
  = note: required because it appears within the type `(syn::PathSegment, syn::token::Colon2)`
  = note: required because it appears within the type `*const (syn::PathSegment, syn::token::Colon2)`
  = note: required because it appears within the type `std::ptr::Unique<(syn::PathSegment, syn::token::Colon2)>`
  = note: required because it appears within the type `alloc::raw_vec::RawVec<(syn::PathSegment, syn::token::Colon2)>`
  = note: required because it appears within the type `std::vec::Vec<(syn::PathSegment, syn::token::Colon2)>`
  = note: required because it appears within the type `syn::punctuated::Punctuated<syn::PathSegment, syn::token::Colon2>`
  = note: required because it appears within the type `syn::Path`
  = note: required because it appears within the type `syn::Attribute`
  = note: required because it appears within the type `*const syn::Attribute`
  = note: required because it appears within the type `std::ptr::Unique<syn::Attribute>`
  = note: required because it appears within the type `alloc::raw_vec::RawVec<syn::Attribute>`
  = note: required because it appears within the type `std::vec::Vec<syn::Attribute>`
  = note: required because it appears within the type `syn::LifetimeDef`
  = note: required because it appears within the type `(syn::LifetimeDef, syn::token::Comma)`
  = note: required because it appears within the type `*const (syn::LifetimeDef, syn::token::Comma)`
  = note: required because it appears within the type `std::ptr::Unique<(syn::LifetimeDef, syn::token::Comma)>`
  = note: required because it appears within the type `alloc::raw_vec::RawVec<(syn::LifetimeDef, syn::token::Comma)>`
  = note: required because it appears within the type `std::vec::Vec<(syn::LifetimeDef, syn::token::Comma)>`
  = note: required because it appears within the type `syn::punctuated::Punctuated<syn::LifetimeDef, syn::token::Comma>`
  = note: required because it appears within the type `syn::BoundLifetimes`
  = note: required because it appears within the type `std::option::Option<syn::BoundLifetimes>`
  = note: required because it appears within the type `syn::PredicateType`
  = note: required because it appears within the type `syn::WherePredicate`
  = note: required because it appears within the type `*const syn::WherePredicate`
  = note: required because it appears within the type `std::ptr::Unique<syn::WherePredicate>`
  = note: required because it appears within the type `alloc::raw_vec::RawVec<syn::WherePredicate>`
  = note: required because it appears within the type `std::vec::Vec<syn::WherePredicate>`
  = note: required because it appears within the type `std::option::Option<std::vec::Vec<syn::WherePredicate>>`
  = note: required because it appears within the type `attr::InputClone`
  = note: required because it appears within the type `std::option::Option<attr::InputClone>`
  = note: required because it appears within the type `attr::Input`
  = note: required because it appears within the type `ast::Input<'a>`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0275`.
error: Could not document `derivative`.

```