### PR TITLE
Remove "full" feature from syn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro = true
 compiletest_rs = { version = "^0.3.14", optional = true }
 proc-macro2 = "^0.4.13"
 quote = "^0.6.3"
-syn = { version = "^0.15.10", features = ["full", "visit", "extra-traits"] }
+syn = { version = "^0.15.10", features = ["visit", "extra-traits"] }
 
 [features]
 test-nightly = ["compiletest_rs"]


### PR DESCRIPTION
It seems that the library might not need to use the `full` feature of `syn`. This PR removes it to potentially help improve compile times for end users. If I'm missing something please let me know =).