### PR TITLE
Add some non-scalar value tests for Default.

### DIFF
--- a/tests/derive-default.rs
+++ b/tests/derive-default.rs
@@ -20,6 +20,26 @@ struct Bar (
     u8,
 );
 
+#[derive(Debug, PartialEq)]
+struct B1(u8, u8);
+#[derive(Debug, PartialEq)]
+struct B2{a:u8, b:u8}
+
+#[derive(Debug, Derivative, PartialEq)]
+#[derivative(Default(new="true"))]
+struct Baz (
+    #[derivative(Default(value="[1,2]"))]
+    [u8;2],
+    #[derivative(Default(value="[3;2]"))]
+    [u8;2],
+    #[derivative(Default(value="(4,5)"))]
+    (u8, u8),
+    #[derivative(Default(value="B1(6,7)"))]
+    B1,
+    #[derivative(Default(value="B2{a:8,b:9}"))]
+    B2,
+);
+
 #[derive(Debug, Derivative, PartialEq)]
 #[derivative(Default)]
 enum Enum1 {
@@ -51,6 +71,7 @@ fn main() {
     assert_eq!(Foo::new(), Foo { foo: 0, bar: 42 });
     assert_eq!(Bar::default(), Bar(0, 42));
     assert_eq!(Bar::new(), Bar(0, 42));
+    assert_eq!(Baz::new(), Baz([1,2], [3,3], (4,5), B1(6,7), B2{a:8,b:9}));
     assert_eq!(A::default(), A(NoDefault));
     assert_eq!(Enum1::default(), Enum1::B);
     assert_eq!(Enum2::default(), Enum2::A);


### PR DESCRIPTION
PR #38 made Default expressions with e.g. list values fail and there
weren't any tests for them.

These tests pass at 1fd45f3e455fb8be752effac867915269ea6e833 but currently fail because of the change in PR #38.
