### PR TITLE
Upgrade to syn/quote/proc-macro2 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: false
 
 rust:
-  - 1.31.0  # Minimum supported version
+  - 1.34.0  # Minimum supported version
   - stable
   - beta
   - nightly
@@ -19,17 +19,13 @@ install:
   - if ${HAS_CLIPPY}; then cargo clippy -V; fi
 
 script:
-  - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then export FEATURES="--features=test-nightly"; else export FEATURES= ; fi
-  - cargo build --verbose ${FEATURES}
-  - cargo test --verbose ${FEATURES}
-  - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then export FEATURES="--features=test-nightly,use_core"; else export FEATURES="--features=use_core" ; fi
+  - cargo build --verbose
+  - cargo test --verbose
   - cargo clean
-  - cargo build --verbose ${FEATURES}
-  - cargo test --verbose ${FEATURES}
-  - if ${HAS_CLIPPY}; then cargo clippy --verbose ${FEATURES}; fi
+  - cargo build --verbose --features=use_core
+  - cargo test --verbose --features=use_core
+  - if ${HAS_CLIPPY}; then cargo clippy --verbose --features=use_core; fi
 
-  # trybuild is not compatible with `-Z minimal-versions`, so do
-  # not use the "test-nightly" feature
   - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then cargo update -Z minimal-versions; fi
   - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then cargo build --verbose; fi
   - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then cargo test --verbose; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: false
 
 rust:
-  - 1.15.0  # Minimum supported version
+  - 1.31.0  # Minimum supported version
   - stable
   - beta
   - nightly
@@ -13,7 +13,7 @@ os:
 
 install:
   # Some toolchains don't ship clippy, so handle this case to not break the build
-  - if [ ${TRAVIS_RUST_VERSION} != "1.15.0" ] && rustup component add clippy-preview; then export HAS_CLIPPY=true; else export HAS_CLIPPY=false; fi
+  - if rustup component add clippy-preview; then export HAS_CLIPPY=true; else export HAS_CLIPPY=false; fi
   - rustc -V
   - cargo -V
   - if ${HAS_CLIPPY}; then cargo clippy -V; fi
@@ -28,7 +28,7 @@ script:
   - cargo test --verbose ${FEATURES}
   - if ${HAS_CLIPPY}; then cargo clippy --verbose ${FEATURES}; fi
 
-  # `compiletest_rs` 0.3.14 is not compatible with `-Z minimal-versions`, so do
+  # trybuild is not compatible with `-Z minimal-versions`, so do
   # not use the "test-nightly" feature
   - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then cargo update -Z minimal-versions; fi
   - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then cargo build --verbose; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,8 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0.3", features = ["visit", "extra-traits"] }
 
- # This really should be [dev-dependencies] but is not available on 1.15,
- # and [dev-dependencies] cannot be optionnal
-trybuild = { version = "1.0", optional = true }
+[dev-dependencies]
+trybuild = "1.0.18"
 
 [features]
-test-nightly = ["trybuild"]
 use_core = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ appveyor = { repository = "mcarton/rust-derivative" }
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "^0.4.13"
-quote = "^0.6.3"
-syn = { version = "^0.15.10", features = ["visit", "extra-traits"] }
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0.3", features = ["visit", "extra-traits"] }
 
  # This really should be [dev-dependencies] but is not available on 1.15,
  # and [dev-dependencies] cannot be optionnal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
       MSYS2_BITS: 32
 
 configuration:
-  - 1.15.0  # Minimum supported version
+  - 1.31.0  # Minimum supported version
   - stable
   - nightly
   - beta
@@ -24,7 +24,7 @@ install:
   - if defined MSYS2_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS2_BITS%\bin
   # Only install `clippy` for 64-bit targets; for reasoning see
   # <https://github.com/rust-lang-nursery/rust-clippy/issues/3202#issuecomment-431641932>
-  - if not "%CONFIGURATION%" == "1.15.0" if not "x%TARGET:x86_64=%" == "x%TARGET%" rustup component add clippy-preview && set HAS_CLIPPY=y
+  - if not "x%TARGET:x86_64=%" == "x%TARGET%" rustup component add clippy-preview && set HAS_CLIPPY=y
   - rustc -V
   - cargo -V
   - if defined HAS_CLIPPY cargo clippy -V
@@ -40,7 +40,7 @@ test_script:
   - cargo test --verbose %FEATURES%
   - if defined HAS_CLIPPY cargo clippy --verbose %FEATURES%
 
-  # `compiletest_rs` 0.3.14 is not compatible with `-Z minimal-versions`, so do
+  # trybuild is not compatible with `-Z minimal-versions`, so do
   # not use the "test-nightly" feature
   - if "%CONFIGURATION%" == "nightly" cargo update -Z minimal-versions
   - if "%CONFIGURATION%" == "nightly" cargo build --verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
       MSYS2_BITS: 32
 
 configuration:
-  - 1.31.0  # Minimum supported version
+  - 1.34.0  # Minimum supported version
   - stable
   - nightly
   - beta
@@ -24,7 +24,7 @@ install:
   - if defined MSYS2_BITS set PATH=%PATH%;C:\msys64\mingw%MSYS2_BITS%\bin
   # Only install `clippy` for 64-bit targets; for reasoning see
   # <https://github.com/rust-lang-nursery/rust-clippy/issues/3202#issuecomment-431641932>
-  - if not "x%TARGET:x86_64=%" == "x%TARGET%" rustup component add clippy-preview && set HAS_CLIPPY=y
+  - if not "x%TARGET:x86_64=%" == "x%TARGET%" rustup component add clippy-preview && set HAS_CLIPPY=y || cd .
   - rustc -V
   - cargo -V
   - if defined HAS_CLIPPY cargo clippy -V
@@ -32,16 +32,12 @@ install:
 build: false
 
 test_script:
-  - if "%CONFIGURATION%" == "nightly" (set FEATURES="--features=test-nightly") else (set FEATURES=)
-  - cargo build --verbose %FEATURES%
-  - cargo test --verbose %FEATURES%
+  - cargo build --verbose
+  - cargo test --verbose
   - cargo clean
-  - if "%CONFIGURATION%" == "nightly" (set FEATURES="--features=test-nightly,use_core") else (set FEATURES="--features=use_core")
-  - cargo test --verbose %FEATURES%
-  - if defined HAS_CLIPPY cargo clippy --verbose %FEATURES%
+  - cargo test --verbose --features=use_core
+  - if defined HAS_CLIPPY cargo clippy --verbose --features=use_core
 
-  # trybuild is not compatible with `-Z minimal-versions`, so do
-  # not use the "test-nightly" feature
   - if "%CONFIGURATION%" == "nightly" cargo update -Z minimal-versions
   - if "%CONFIGURATION%" == "nightly" cargo build --verbose
   - if "%CONFIGURATION%" == "nightly" cargo test --verbose

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -613,14 +613,19 @@ struct MetaItem<'a>(
 fn read_items(item: &syn::NestedMeta) -> Result<MetaItem, String> {
     let item = match *item {
         syn::NestedMeta::Meta(ref item) => item,
-        syn::NestedMeta::Literal(..) => {
+        syn::NestedMeta::Lit(..) => {
             return Err("Expected meta-item but found literal".to_string());
         }
     };
     match *item {
-        syn::Meta::Word(ref name) => Ok(MetaItem(name, Vec::new())),
+        syn::Meta::Path(ref path) => match path.get_ident() {
+            Some(name) => Ok(MetaItem(name, Vec::new())),
+            None => {
+                return Err("expected derivative attribute to be a string, but found a path".into())
+            }
+        },
         syn::Meta::List(syn::MetaList {
-            ident: ref name,
+            ref path,
             nested: ref values,
             ..
         }) => {
@@ -628,12 +633,12 @@ fn read_items(item: &syn::NestedMeta) -> Result<MetaItem, String> {
                 .iter()
                 .map(|value| {
                     if let syn::NestedMeta::Meta(syn::Meta::NameValue(syn::MetaNameValue {
-                        ident: ref name,
+                        ref path,
                         lit: ref value,
                         ..
                     })) = *value
                     {
-                        let value = try!(ensure_str_lit(&name.to_string(), value));
+                        let (name, value) = try!(ensure_str_lit(&path, &value));
 
                         Ok((Some(name), Some(value)))
                     } else {
@@ -642,14 +647,23 @@ fn read_items(item: &syn::NestedMeta) -> Result<MetaItem, String> {
                 })
                 .collect());
 
+            let name = match path.get_ident() {
+                Some(name) => name,
+                None => {
+                    return Err(
+                        "expected derivative attribute to be a string, but found a path".into(),
+                    )
+                }
+            };
+
             Ok(MetaItem(name, values))
         }
         syn::Meta::NameValue(syn::MetaNameValue {
-            ident: ref name,
+            ref path,
             lit: ref value,
             ..
         }) => {
-            let value = try!(ensure_str_lit(&name.to_string(), value));
+            let (name, value) = try!(ensure_str_lit(&path, &value));
 
             Ok(MetaItem(name, vec![(None, Some(value))]))
         }
@@ -662,11 +676,12 @@ fn derivative_attribute(
 ) -> Option<syn::punctuated::Punctuated<syn::NestedMeta, syn::token::Comma>> {
     match meta {
         Ok(syn::Meta::List(syn::MetaList {
-            ident: name,
-            nested: mis,
-            ..
+            path, nested: mis, ..
         })) => {
-            if name == "derivative" {
+            if path
+                .get_ident()
+                .map_or(false, |ident| ident == "derivative")
+            {
                 Some(mis)
             } else {
                 None
@@ -731,9 +746,18 @@ where
     value.parse().map_err(|e| e.to_string())
 }
 
-fn ensure_str_lit<'a>(attr_name: &str, lit: &'a syn::Lit) -> Result<&'a syn::LitStr, String> {
+fn ensure_str_lit<'a>(
+    attr_path: &'a syn::Path,
+    lit: &'a syn::Lit,
+) -> Result<(&'a syn::Ident, &'a syn::LitStr), String> {
+    let attr_name = match attr_path.get_ident() {
+        Some(attr_name) => attr_name,
+        None => {
+            return Err("expected derivative attribute to be a string, but found a path".into())
+        }
+    };
     if let syn::Lit::Str(ref lit) = *lit {
-        Ok(lit)
+        Ok((attr_name, lit))
     } else {
         Err(format!(
             "expected derivative {} attribute to be a string: `{} = \"...\"`",

--- a/src/bound.rs
+++ b/src/bound.rs
@@ -168,7 +168,7 @@ where
 
 fn is_phantom_data(path: &syn::Path) -> bool {
     match path.segments.last() {
-        Some(syn::punctuated::Pair::End(seg)) if seg.ident == "PhantomData" => true,
+        Some(path) if path.ident == "PhantomData" => true,
         _ => false,
     }
 }


### PR DESCRIPTION
Fix #43. This is a more surgical resubmission of #50 that doesn't attempt to upgrade the edition or run rustfmt. It would be absolutely lovely to get this into a release—derivative is the last crate in our graph that still depends on non-1.0 syn/quote/proc-macro2!