### PR TITLE
Fix some warnings in tests from rustc

### DIFF
--- a/tests/rustc-deriving-copyclone.rs
+++ b/tests/rustc-deriving-copyclone.rs
@@ -17,7 +17,7 @@ extern crate core;
 #[macro_use]
 extern crate derivative;
 
-use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// A struct that pretends to be Copy, but actually does something
 /// in its Clone impl
@@ -25,7 +25,7 @@ use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
 struct Liar;
 
 /// Static cooperating with the rogue Clone impl
-static CLONED: AtomicBool = ATOMIC_BOOL_INIT;
+static CLONED: AtomicBool = AtomicBool::new(false);
 
 impl Clone for Liar {
     fn clone(&self) -> Self {

--- a/tests/rustc-issue-28561.rs
+++ b/tests/rustc-issue-28561.rs
@@ -116,7 +116,7 @@ struct Fn<A, B, C, D, E, F, G, H, I, J, K, L> {
 // TODO: Ord, PartialOrd
 struct Tuple<A, B, C, D, E, F, G, H, I, J, K, L> {
     f00: (),
-    f01: (A),
+    f01: (A,),
     f02: (A, B),
     f03: (A, B, C),
     f04: (A, B, C, D),


### PR DESCRIPTION
This is partly thanks to changing the minimum required version to
1.34.0.