### PR TITLE
Deprecate `feature_allow_slow_enum` for `PartialEq`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased - 2.1.0
+* `feature_allow_slow_enum` is not required anymore on `enum` with `PartialEq`.
+
 ## 2.0.2
 * Fix a bug with `format_with` on `Debug` derives with generic types with trait bounds.
 

--- a/doc/cmp.md
+++ b/doc/cmp.md
@@ -18,17 +18,19 @@ The `PartialEq`, `PartialOrd` and `Ord` traits also supports the following attri
 
 # Enumerations
 
-Unfortunately, there is no way for derivative to derive `PartialEq`, `PartialOrd` or `Ord` on
-enumerations as efficiently as the built-in `derive(…)`
-[yet][discriminant].
+Unfortunately, there is no way for derivative to derive `PartialOrd` or `Ord` on
+enumerations as efficiently as the built-in `derive(…)` yet.
 
 If you want to use derivative on enumerations anyway, you can add
 
 ```rust
-#[derivative(PartialEq="feature_allow_slow_enum")]
+#[derivative(PartialOrd="feature_allow_slow_enum")]
 ```
 
 to your enumeration. This acts as a “feature-gate”.
+
+This attribute is also allowed for `PartialEq` for historical reason. It is not
+necessary anymore as of v2.1.0. It was never necessary nor allowed for `Eq`.
 
 # Ignoring a field
 
@@ -89,5 +91,3 @@ struct WithPtr<T: ?Sized> {
 ```
 
 See [`Default`'s documentation](./Default.md#custom-bound) for more details.
-
-[discriminant]: https://github.com/rust-lang/rfcs/pull/1696

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -100,8 +100,6 @@ pub struct InputHash {
 pub struct InputPartialEq {
     /// The `bound` attribute if present and the corresponding bounds.
     bounds: Option<Vec<syn::WherePredicate>>,
-    /// Allow `derivative(PartialEq)` on enums:
-    on_enum: bool,
 }
 
 #[derive(Debug, Default)]
@@ -304,9 +302,7 @@ impl Input {
                     let Some(partial_eq) = input.partial_eq;
                     for value in values;
                     "bound" => try!(parse_bound(&mut partial_eq.bounds, value)),
-                    "feature_allow_slow_enum" => {
-                        partial_eq.on_enum = try!(parse_boolean_meta_item(value, true, "feature_allow_slow_enum"));
-                    }
+                    "feature_allow_slow_enum" => (), // backward compatibility, now unnecessary
                 }
             }
             "PartialOrd" => {
@@ -394,10 +390,6 @@ impl Input {
         self.ord
             .as_ref()
             .and_then(|d| d.bounds.as_ref().map(Vec::as_slice))
-    }
-
-    pub fn partial_eq_on_enum(&self) -> bool {
-        self.partial_eq.as_ref().map_or(false, |d| d.on_enum)
     }
 
     pub fn partial_ord_on_enum(&self) -> bool {

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -53,6 +53,7 @@ pub fn derive_clone(input: &ast::Input) -> proc_macro2::TokenStream {
     } else {
         let body = matcher::Matcher::new(matcher::BindingStyle::Ref).build_arms(
             input,
+            "__arg",
             |arm_path, _, _, style, _, bis| {
                 let field_clones = bis.iter().map(|bi| {
                     let arg = &bi.ident;
@@ -98,10 +99,10 @@ pub fn derive_clone(input: &ast::Input) -> proc_macro2::TokenStream {
             Some(
                 matcher::Matcher::new(matcher::BindingStyle::RefMut).build_arms(
                     input,
+                    "__arg",
                     |outer_arm_path, _, _, _, _, outer_bis| {
                         let body = matcher::Matcher::new(matcher::BindingStyle::Ref)
-                            .with_name("__other".into())
-                            .build_arms(input, |inner_arm_path, _, _, _, _, inner_bis| {
+                            .build_arms(input, "__other", |inner_arm_path, _, _, _, _, inner_bis| {
                                 if outer_arm_path == inner_arm_path {
                                     let field_clones = outer_bis.iter().zip(inner_bis).map(
                                         |(outer_bi, inner_bi)| {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -14,6 +14,7 @@ pub fn derive(input: &ast::Input) -> proc_macro2::TokenStream {
 
     let body = matcher::Matcher::new(matcher::BindingStyle::Ref).build_arms(
         input,
+        "__arg",
         |_, _, arm_name, style, attrs, bis| {
             let field_prints = bis.iter().filter_map(|bi| {
                 if bi.field.attrs.ignore_debug() {

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -12,6 +12,7 @@ pub fn derive(input: &ast::Input) -> proc_macro2::TokenStream {
 
     let body = matcher::Matcher::new(matcher::BindingStyle::Ref).build_arms(
         input,
+        "__arg",
         |arm_path, _, _, _, _, bis| {
             let field_prints = bis.iter().filter_map(|bi| {
                 if bi.field.attrs.ignore_hash() {

--- a/tests/derive-partial-eq.rs
+++ b/tests/derive-partial-eq.rs
@@ -12,11 +12,33 @@ struct Foo {
     foo: u8,
 }
 
+/// Test for backward compatibility.
 #[derive(Derivative)]
 #[derivative(PartialEq = "feature_allow_slow_enum")]
+#[allow(unused)]
+enum AllowsFeature<T> {
+    Some(T),
+    None,
+}
+
+#[derive(Derivative)]
+#[derivative(PartialEq)]
 enum Option<T> {
     Some(T),
     None,
+}
+
+#[derive(Derivative)]
+#[derivative(PartialEq)]
+enum SimpleEnum {
+    Some,
+    None,
+}
+
+#[derive(Derivative)]
+#[derivative(PartialEq)]
+enum UnitEnum {
+    Single,
 }
 
 #[derive(Derivative)]
@@ -98,6 +120,13 @@ fn main() {
     assert!(Option::Some(42) != Option::None);
     assert!(Option::None != Option::Some(42));
     assert!(Option::None::<u8> == Option::None::<u8>);
+
+    assert!(SimpleEnum::Some == SimpleEnum::Some);
+    assert!(SimpleEnum::None == SimpleEnum::None);
+    assert!(SimpleEnum::Some != SimpleEnum::None);
+    assert!(SimpleEnum::None != SimpleEnum::Some);
+
+    assert!(UnitEnum::Single == UnitEnum::Single);
 
     assert!(Parity(3) == Parity(7));
     assert!(Parity(2) == Parity(42));


### PR DESCRIPTION
This is not required anymore as `std::mem::Discriminant` was stabilized
in Rust 1.21.0 and our minimum Rust version is now 1.34.0.

Closes  #63.