### PR TITLE
Remove `derive(Default)` attribute for `RegexOptions` (example)

### DIFF
--- a/doc/default-value-orig.rs
+++ b/doc/default-value-orig.rs
@@ -1,4 +1,3 @@
-#[derive(Default)]
 pub struct RegexOptions {
     pub pats: Vec&lt;String&gt;,
     pub size_limit: usize,


### PR DESCRIPTION
`derive(Default)` attributes conflicts with manual `Default` implementation for `RegexOptions`.