### PR TITLE
Fix a clippy warning when using clone_from = "true" 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   - cargo clean
   - cargo build --verbose --features=use_core
   - cargo test --verbose --features=use_core
-  - if ${HAS_CLIPPY}; then cargo clippy --verbose --features=use_core; fi
+  - if ${HAS_CLIPPY}; then cargo clippy --verbose --all-targets --features=use_core; fi
 
   - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then cargo update -Z minimal-versions; fi
   - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then cargo build --verbose; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ test_script:
   - cargo test --verbose
   - cargo clean
   - cargo test --verbose --features=use_core
-  - if defined HAS_CLIPPY cargo clippy --verbose --features=use_core
+  - if defined HAS_CLIPPY cargo clippy --verbose --all-targets --features=use_core
 
   - if "%CONFIGURATION%" == "nightly" cargo update -Z minimal-versions
   - if "%CONFIGURATION%" == "nightly" cargo build --verbose

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -147,6 +147,7 @@ pub fn derive_clone(input: &ast::Input) -> proc_macro2::TokenStream {
             };
 
             quote! {
+                #[allow(clippy::needless_return)]
                 fn clone_from(&mut self, other: &Self) {
                     match *self {
                         #body

--- a/tests/clippy-warning-clone-from.rs
+++ b/tests/clippy-warning-clone-from.rs
@@ -1,0 +1,13 @@
+#![deny(clippy::all)]
+
+#[cfg(feature = "use_core")]
+extern crate core;
+
+#[macro_use]
+extern crate derivative;
+
+#[derive(Derivative)]
+#[derivative(Clone(clone_from = "true"))]
+pub struct Foo {}
+
+fn main() {}

--- a/tests/derive-clone.rs
+++ b/tests/derive-clone.rs
@@ -10,12 +10,12 @@ extern crate derivative;
 #[derivative(Clone)]
 struct Foo {
     foo: u8,
-    #[derivative(Clone(clone_with="seventh"))]
+    #[derivative(Clone(clone_with = "seventh"))]
     bar: u8,
 }
 
 fn seventh(a: &u8) -> u8 {
-    a/7
+    a / 7
 }
 
 #[derive(Debug, PartialEq)]
@@ -32,15 +32,15 @@ impl Clone for EvilCloneFrom {
 }
 
 #[derive(Derivative)]
-#[derivative(Clone(clone_from="true"))]
+#[derivative(Clone(clone_from = "true"))]
 struct StructWithCloneFrom(EvilCloneFrom);
 
 #[derive(Debug, Derivative, PartialEq)]
-#[derivative(Clone(clone_from="true"))]
+#[derivative(Clone(clone_from = "true"))]
 enum EnumWithCloneFrom {
     Evil(EvilCloneFrom),
     Good(u32),
-    None
+    None,
 }
 
 #[test]

--- a/tests/derive-clone.rs
+++ b/tests/derive-clone.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::blacklisted_name, clippy::redundant_clone)]
+
 #[cfg(feature = "use_core")]
 extern crate core;
 

--- a/tests/derive-eq.rs
+++ b/tests/derive-eq.rs
@@ -9,14 +9,14 @@ extern crate derivative;
 #[derive(Derivative, PartialEq)]
 #[derivative(Eq)]
 struct Foo {
-    foo: u8
+    foo: u8,
 }
 
 #[derive(Derivative)]
 #[derivative(Eq)]
 struct WithPtr<T: ?Sized> {
-    #[derivative(Eq(bound=""))]
-    foo: *const T
+    #[derivative(Eq(bound = ""))]
+    foo: *const T,
 }
 
 impl<T: ?Sized> PartialEq for WithPtr<T> {
@@ -28,7 +28,7 @@ impl<T: ?Sized> PartialEq for WithPtr<T> {
 trait SomeTrait {}
 struct SomeType {
     #[allow(dead_code)]
-    foo: u8
+    foo: u8,
 }
 impl SomeTrait for SomeType {}
 

--- a/tests/derive-eq.rs
+++ b/tests/derive-eq.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::eq_op)]
+
 #[cfg(feature = "use_core")]
 extern crate core;
 

--- a/tests/derive-partial-eq.rs
+++ b/tests/derive-partial-eq.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::eq_op)]
+
 #[cfg(feature = "use_core")]
 extern crate core;
 

--- a/tests/rustc-class-implement-traits.rs
+++ b/tests/rustc-class-implement-traits.rs
@@ -44,10 +44,10 @@ impl cat {
         if self.how_hungry > 0 {
             println!("OM NOM NOM");
             self.how_hungry -= 2;
-            return true;
+            true
         } else {
             println!("Not hungry!");
-            return false;
+            false
         }
     }
 }
@@ -60,7 +60,7 @@ fn cat(in_x : usize, in_y : isize, in_name: String) -> cat {
     cat {
         meows: in_x,
         how_hungry: in_y,
-        name: in_name.clone()
+        name: in_name,
     }
 }
 

--- a/tests/rustc-class-implement-traits.rs
+++ b/tests/rustc-class-implement-traits.rs
@@ -23,10 +23,10 @@ trait noisy {
 #[derive(Derivative)]
 #[derivative(Clone)]
 struct cat {
-    meows : usize,
+    meows: usize,
 
-    how_hungry : isize,
-    name : String,
+    how_hungry: isize,
+    name: String,
 }
 
 impl cat {
@@ -53,10 +53,12 @@ impl cat {
 }
 
 impl noisy for cat {
-    fn speak(&mut self) { self.meow(); }
+    fn speak(&mut self) {
+        self.meow();
+    }
 }
 
-fn cat(in_x : usize, in_y : isize, in_name: String) -> cat {
+fn cat(in_x: usize, in_y: isize, in_name: String) -> cat {
     cat {
         meows: in_x,
         how_hungry: in_y,
@@ -64,8 +66,7 @@ fn cat(in_x : usize, in_y : isize, in_name: String) -> cat {
     }
 }
 
-
-fn make_speak<C:noisy>(mut c: C) {
+fn make_speak<C: noisy>(mut c: C) {
     c.speak();
 }
 

--- a/tests/rustc-deriving-clone-struct.rs
+++ b/tests/rustc-deriving-clone-struct.rs
@@ -38,7 +38,7 @@ struct S {
 
     _bool: bool,
     _char: char,
-    _nil: ()
+    _nil: (),
 }
 
 #[test]

--- a/tests/rustc-deriving-clone-struct.rs
+++ b/tests/rustc-deriving-clone-struct.rs
@@ -10,6 +10,8 @@
 
 // pretty-expanded FIXME #23616
 
+#![allow(clippy::redundant_clone)]
+
 #[cfg(feature = "use_core")]
 extern crate core;
 

--- a/tests/rustc-deriving-copyclone.rs
+++ b/tests/rustc-deriving-copyclone.rs
@@ -11,6 +11,8 @@
 //! Test that #[derive(Copy, Clone)] produces a shallow copy
 //! even when a member violates RFC 1521
 
+#![allow(clippy::clone_on_copy)]
+
 #[cfg(feature = "use_core")]
 extern crate core;
 

--- a/tests/rustc-deriving-hash.rs
+++ b/tests/rustc-deriving-hash.rs
@@ -16,8 +16,8 @@ extern crate core;
 #[macro_use]
 extern crate derivative;
 
-use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 #[derive(Derivative)]
 #[derivative(Hash)]
@@ -29,14 +29,20 @@ struct Person {
 
 // test for hygiene name collisions
 #[derive(Derivative)]
-#[derivative(Hash)] struct __H__H;
+#[derivative(Hash)]
+struct __H__H;
 #[derive(Derivative)]
-#[allow(dead_code)] #[derivative(Hash)] struct Collision<__H> ( __H );
+#[allow(dead_code)]
+#[derivative(Hash)]
+struct Collision<__H>(__H);
 // TODO(rustc) #[derivative(Hash)] enum Collision<__H> { __H { __H__H: __H } }
 
 #[derive(Derivative)]
 #[derivative(Hash)]
-enum E { A=1, B }
+enum E {
+    A = 1,
+    B,
+}
 
 fn hash<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();

--- a/tests/rustc-deriving-hash.rs
+++ b/tests/rustc-deriving-hash.rs
@@ -64,12 +64,12 @@ fn main() {
     let person1 = Person {
         id: 5,
         name: "Janet".to_string(),
-        phone: 555_666_7777
+        phone: 555_666_777,
     };
     let person2 = Person {
         id: 5,
         name: "Bob".to_string(),
-        phone: 555_666_7777
+        phone: 555_666_777,
     };
     assert_eq!(hash(&person1), hash(&person1));
     assert!(hash(&person1) != hash(&person2));

--- a/tests/rustc-deriving-meta-multiple.rs
+++ b/tests/rustc-deriving-meta-multiple.rs
@@ -27,16 +27,16 @@ use std::hash::Hash;
 #[derivative(Hash)]
 struct Foo {
     bar: usize,
-    baz: isize
+    baz: isize,
 }
 
 fn hash<T: Hash>(_t: &T) {}
 
 #[test]
 fn main() {
-    let a = Foo {bar: 4, baz: -3};
+    let a = Foo { bar: 4, baz: -3 };
 
-    let _ = a == a;    // check for PartialEq impl w/o testing its correctness
+    let _ = a == a; // check for PartialEq impl w/o testing its correctness
     let _ = a.clone(); // check for Clone impl w/o testing its correctness
-    hash(&a);  // check for Hash impl w/o testing its correctness
+    hash(&a); // check for Hash impl w/o testing its correctness
 }

--- a/tests/rustc-deriving-meta-multiple.rs
+++ b/tests/rustc-deriving-meta-multiple.rs
@@ -10,6 +10,8 @@
 
 // pretty-expanded FIXME #23616
 
+#![allow(clippy::eq_op)]
+
 #[cfg(feature = "use_core")]
 extern crate core;
 

--- a/tests/rustc-deriving-meta-multiple.rs
+++ b/tests/rustc-deriving-meta-multiple.rs
@@ -10,7 +10,7 @@
 
 // pretty-expanded FIXME #23616
 
-#![allow(clippy::eq_op)]
+#![allow(clippy::eq_op, clippy::redundant_clone)]
 
 #[cfg(feature = "use_core")]
 extern crate core;

--- a/tests/rustc-deriving-meta.rs
+++ b/tests/rustc-deriving-meta.rs
@@ -24,16 +24,16 @@ use std::hash::Hash;
 #[derivative(PartialEq, Clone, Hash)]
 struct Foo {
     bar: usize,
-    baz: isize
+    baz: isize,
 }
 
 fn hash<T: Hash>(_t: &T) {}
 
 #[test]
 fn main() {
-    let a = Foo {bar: 4, baz: -3};
+    let a = Foo { bar: 4, baz: -3 };
 
-    let _ = a == a;    // check for PartialEq impl w/o testing its correctness
+    let _ = a == a; // check for PartialEq impl w/o testing its correctness
     let _ = a.clone(); // check for Clone impl w/o testing its correctness
-    hash(&a);  // check for Hash impl w/o testing its correctness
+    hash(&a); // check for Hash impl w/o testing its correctness
 }

--- a/tests/rustc-deriving-meta.rs
+++ b/tests/rustc-deriving-meta.rs
@@ -10,6 +10,8 @@
 
 // pretty-expanded FIXME #23616
 
+#![allow(clippy::eq_op)]
+
 #[cfg(feature = "use_core")]
 extern crate core;
 

--- a/tests/rustc-deriving-meta.rs
+++ b/tests/rustc-deriving-meta.rs
@@ -10,7 +10,7 @@
 
 // pretty-expanded FIXME #23616
 
-#![allow(clippy::eq_op)]
+#![allow(clippy::eq_op, clippy::redundant_clone)]
 
 #[cfg(feature = "use_core")]
 extern crate core;

--- a/tests/rustc-issue-12860.rs
+++ b/tests/rustc-issue-12860.rs
@@ -24,7 +24,7 @@ extern crate derivative;
 struct XYZ {
     x: isize,
     y: isize,
-    z: isize
+    z: isize,
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn main() {
     let mut connected = HashSet::new();
     let mut border = HashSet::new();
 
-    let middle = XYZ{x: 0, y: 0, z: 0};
+    let middle = XYZ { x: 0, y: 0, z: 0 };
     border.insert(middle);
 
     while !border.is_empty() && connected.len() < 10000 {
@@ -40,26 +40,50 @@ fn main() {
         border.remove(&choice);
         connected.insert(choice);
 
-        let cxp = XYZ{x: choice.x + 1, y: choice.y, z: choice.z};
-        let cxm = XYZ{x: choice.x - 1, y: choice.y, z: choice.z};
-        let cyp = XYZ{x: choice.x, y: choice.y + 1, z: choice.z};
-        let cym = XYZ{x: choice.x, y: choice.y - 1, z: choice.z};
-        let czp = XYZ{x: choice.x, y: choice.y, z: choice.z + 1};
-        let czm = XYZ{x: choice.x, y: choice.y, z: choice.z - 1};
+        let cxp = XYZ {
+            x: choice.x + 1,
+            y: choice.y,
+            z: choice.z,
+        };
+        let cxm = XYZ {
+            x: choice.x - 1,
+            y: choice.y,
+            z: choice.z,
+        };
+        let cyp = XYZ {
+            x: choice.x,
+            y: choice.y + 1,
+            z: choice.z,
+        };
+        let cym = XYZ {
+            x: choice.x,
+            y: choice.y - 1,
+            z: choice.z,
+        };
+        let czp = XYZ {
+            x: choice.x,
+            y: choice.y,
+            z: choice.z + 1,
+        };
+        let czm = XYZ {
+            x: choice.x,
+            y: choice.y,
+            z: choice.z - 1,
+        };
 
         if !connected.contains(&cxp) {
             border.insert(cxp);
         }
-        if  !connected.contains(&cxm){
+        if !connected.contains(&cxm) {
             border.insert(cxm);
         }
-        if !connected.contains(&cyp){
+        if !connected.contains(&cyp) {
             border.insert(cyp);
         }
         if !connected.contains(&cym) {
             border.insert(cym);
         }
-        if !connected.contains(&czp){
+        if !connected.contains(&czp) {
             border.insert(czp);
         }
         if !connected.contains(&czm) {

--- a/tests/rustc-issue-12860.rs
+++ b/tests/rustc-issue-12860.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(clippy::derive_hash_xor_eq)]
+
 #[cfg(feature = "use_core")]
 extern crate core;
 

--- a/tests/rustc-issue-28561.rs
+++ b/tests/rustc-issue-28561.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(clippy::zero_prefixed_literal, clippy::type_complexity)]
+
 #[cfg(feature = "use_core")]
 extern crate core;
 

--- a/tests/rustc-issue-29030.rs
+++ b/tests/rustc-issue-29030.rs
@@ -23,5 +23,8 @@ struct Message<'a, P: 'a = &'a [u8]> {
 
 #[test]
 fn main() {
-    Message { header: &[1], payload: &[1] };
+    let _ = Message {
+        header: &[1],
+        payload: &[1],
+    };
 }


### PR DESCRIPTION
I also cleaned clippy warning in test, activated `cargo clippy --all-targets` to have clippy running on tests, and some fmt in the modified files.

Each modification is in a different commit, so I can remove some if you prefer.

Fixes #74