### PR TITLE
Added documentation for relaxing trait bounds on PhatomData

### DIFF
--- a/doc/PhantomData.md
+++ b/doc/PhantomData.md
@@ -3,27 +3,61 @@
 
 ## Example
 This:
-```Rust
+```rust
 # extern crate derivative;
 # use derivative::Derivative;
-# use std::marker::PhantomData;
+# use std::{marker::PhantomData, fmt::Debug};
+#
+# struct NonDebug ();
+#
 #[derive(Derivative)]
 #[derivative(Debug(bound = "A: Debug"))]  // bound not needed.
 struct Foo<A, B> {
     a: A,
-    _b: PhantomData<B>,
+    b: PhantomData<B>,
+}
+
+fn main() {
+    let foo: Foo<usize, NonDebug> = Foo{ a: 1, b: PhantomData };
+    println!("{:?}", foo);
 }
 ```
 
 is equivalent to this:
-```Rust
+```rust
 # extern crate derivative;
 # use derivative::Derivative;
-# use std::marker::PhantomData;
+# use std::{marker::PhantomData, fmt::Debug};
+#
+# struct NonDebug ();
+#
 #[derive(Derivative)]
 #[derivative(Debug)]
 struct Foo<A, B> {
     a: A,
-    _b: PhantomData<B>,
+    b: PhantomData<B>,
+}
+
+fn main() {
+    let foo: Foo<usize, NonDebug> = Foo{ a: 1, b: PhantomData };
+    println!("{:?}", foo);
+}
+```
+
+Rust's derive which does not compile because it adds the bound `B: Debug`:
+```rust, compile_fail
+# use std::{marker::PhantomData, fmt::Debug};
+#
+# struct NonDebug ();
+#
+#[derive(Debug)] // This will added the bounds: A: Debug, B: Debug
+struct Foo<A, B> {
+    a: A,
+    b: PhantomData<B>,
+}
+
+fn main() {
+    let foo: Foo<usize, NonDebug> = Foo{ a: 1, b: PhantomData };
+    println!("{:?}", foo); // Won't compile because NonDebug does not implement Debug.
 }
 ```

--- a/doc/PhantomData.md
+++ b/doc/PhantomData.md
@@ -1,0 +1,29 @@
+# PhantomData
+[PhantomData](https://doc.rust-lang.org/std/marker/struct.PhantomData.html) implements all of the derivable traits without placing bounds on the type it is given. Because of this, if a generic type is only used in a `PhantomData`, no bounds are placed on it. This is in contrast to Rust's `derive` which will add the trait bound regardless.
+
+## Example
+This:
+```Rust
+# extern crate derivative;
+# use derivative::Derivative;
+# use std::marker::PhantomData;
+#[derive(Derivative)]
+#[derivative(Debug(bound = "A: Debug"))]  // bound not needed.
+struct Foo<A, B> {
+    a: A,
+    _b: PhantomData<B>,
+}
+```
+
+is equivalent to this:
+```Rust
+# extern crate derivative;
+# use derivative::Derivative;
+# use std::marker::PhantomData;
+#[derive(Derivative)]
+#[derivative(Debug)]
+struct Foo<A, B> {
+    a: A,
+    _b: PhantomData<B>,
+}
+```

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -23,3 +23,4 @@
     <!-- * [Ignoring fields](cmp.md#ignoring-a-field) -->
     <!-- * [Alternative comparison function](cmp.md#compare-with) -->
     <!-- * [Custom bound](cmp.md#custom-bound) -->
+* [PhantomData](PhantomData.md)


### PR DESCRIPTION
I original did not realize that Derivative did not add trait bounds for types only used in PhantomData. So to help new users, I added it to the docs.