### PR TITLE
RFC: use finish_non_exhaustive

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -34,7 +34,7 @@ pub struct Field<'a> {
     pub span: proc_macro2::Span,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Style {
     Struct,
     Tuple,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -72,6 +72,15 @@ pub fn derive(input: &ast::Input) -> proc_macro2::TokenStream {
             };
             let method = syn::Ident::new(method, proc_macro2::Span::call_site());
 
+            let field_prints: Vec<_> = field_prints.collect();
+            let exhaustive = field_prints.len() == bis.len();
+            let finish = if exhaustive || style != ast::Style::Struct {
+                "finish"
+            } else {
+                "finish_non_exhaustive"
+            };
+            let finish = syn::Ident::new(finish, proc_macro2::Span::call_site());
+
             if attrs.debug_transparent() {
                 quote_spanned! {arm_name.span()=>
                     #(#field_prints)*
@@ -81,7 +90,7 @@ pub fn derive(input: &ast::Input) -> proc_macro2::TokenStream {
                 quote_spanned! {arm_name.span()=>
                     let mut __debug_trait_builder = #formatter.#method(#name);
                     #(#field_prints)*
-                    __debug_trait_builder.finish()
+                    __debug_trait_builder.#finish()
                 }
             }
         });

--- a/tests/derive-debug-generics.rs
+++ b/tests/derive-debug-generics.rs
@@ -79,12 +79,12 @@ struct PhantomTuple<T> {
 
 #[test]
 fn main() {
-    assert_eq!(Foo { foo: 42, bar: NoDebug }.to_show(), "Foo { foo: 42 }".to_string());
+    assert_eq!(Foo { foo: 42, bar: NoDebug }.to_show(), "Foo { foo: 42, .. }".to_string());
     assert_eq!(Bar(42, NoDebug).to_show(), "Bar(42)".to_string());
     assert_eq!(C::V1::<i32, NoDebug>(12).to_show(), "V1(12)".to_string());
     assert_eq!(C::V2::<i32, NoDebug>(NoDebug).to_show(), "V2".to_string());
     assert_eq!(C::V3::<i32, NoDebug>("foo".to_string()).to_show(), "V3(\"foo\")".to_string());
-    assert_eq!(D::V1 { a: NoDebug }.to_show(), "V1".to_string());
+    assert_eq!(D::V1 { a: NoDebug }.to_show(), "V1 { .. }".to_string());
     assert_eq!(F(NoDebug).to_show(), "F".to_string());
     assert_eq!(G(42, NoDebug).to_show(), "G(42)".to_string());
     assert_eq!(J(NoDebug).to_show(), "J".to_string());

--- a/tests/derive-debug-packed.rs
+++ b/tests/derive-debug-packed.rs
@@ -64,11 +64,11 @@ impl<T: std::fmt::Debug> ToDebug for T {
 
 #[test]
 fn main() {
-    assert_eq!(Foo { foo: 42, bar: 1 }.to_show(), "Foo { foo: 42 }".to_string());
+    assert_eq!(Foo { foo: 42, bar: 1 }.to_show(), "Foo { foo: 42, .. }".to_string());
     assert_eq!(Bar(42, 1).to_show(), "Bar(42)".to_string());
     assert_eq!(F(42).to_show(), "F".to_string());
     assert_eq!(G(42, 0).to_show(), "G(42)".to_string());
     assert_eq!(J(NoDebug).to_show(), "J".to_string());
     assert_eq!(K(42, NoDebug).to_show(), "K(42)".to_string());
-    assert_eq!(L{ foo: NoDebug }.to_show(), "L".to_string());
+    assert_eq!(L{ foo: NoDebug }.to_show(), "L { .. }".to_string());
 }

--- a/tests/derive-debug.rs
+++ b/tests/derive-debug.rs
@@ -65,12 +65,12 @@ impl<T: std::fmt::Debug> ToDebug for T {
 
 #[test]
 fn main() {
-    assert_eq!(Foo { foo: 42, bar: 1 }.to_show(), "Foo { foo: 42 }".to_string());
+    assert_eq!(Foo { foo: 42, bar: 1 }.to_show(), "Foo { foo: 42, .. }".to_string());
     assert_eq!(Bar(42, 1).to_show(), "Bar(42)".to_string());
     assert_eq!(C::V1(12).to_show(), "V1(12)".to_string());
     assert_eq!(C::V2(12).to_show(), "V2".to_string());
     assert_eq!(C::V3("foo".to_string()).to_show(), "V3(\"foo\")".to_string());
-    assert_eq!(D::V1 { a: 42 }.to_show(), "V1".to_string());
+    assert_eq!(D::V1 { a: 42 }.to_show(), "V1 { .. }".to_string());
     assert_eq!(F(42).to_show(), "F".to_string());
     assert_eq!(G(42, 0).to_show(), "G(42)".to_string());
     assert_eq!(J(NoDebug).to_show(), "J".to_string());


### PR DESCRIPTION
According to rust doc: "Marks the struct as non-exhaustive, indicating
to the reader that there are some other fields that are not shown in the
debug representation.", which is appropriate when we ignore fields.
