### PR TITLE
Avoid hidden lifetime parameters for latest Rust nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/mcarton/rust-derivative"
 description = "A set of alternative `derive` attributes for Rust"
 keywords = ["derive", "macro", "macro1-1", "plugin"]
 categories = ["rust-patterns"]
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ quote = "1.0"
 syn = { version = "1.0.3", features = ["visit", "extra-traits"] }
 
 [dev-dependencies]
-# 1.0.23 requires rustc 1.36, while our msrv is 1.34
 runtime-macros-derive = "0.4.0"
+# 1.0.23 requires rustc 1.36, while our msrv is 1.34
 trybuild = "1.0.18, <1.0.23"
 walkdir = "2"
 # 1.0.73 requires itoa 1.0.0, which requires rustc 1.36, while our msrv is 1.34

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,11 @@ syn = { version = "1.0.3", features = ["visit", "extra-traits"] }
 runtime-macros-derive = "0.4.0"
 trybuild = "1.0.18, <1.0.23"
 walkdir = "2"
+# 1.0.73 requires itoa 1.0.0, which requires rustc 1.36, while our msrv is 1.34
+serde_json = "=1.0.72"
+itoa = "=0.4.3"
+# 1.0.7 requires rustc 1.36, while our msrv is 1.34
+ryu = "=1.0.6"
 
 [features]
 use_core = []

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -103,7 +103,7 @@ pub fn derive(input: &ast::Input) -> proc_macro2::TokenStream {
         #[allow(unused_qualifications)]
         #[allow(clippy::unneeded_field_pattern)]
         impl #impl_generics #debug_trait_path for #name #ty_generics #where_clause {
-            fn fmt(&self, #formatter: &mut #fmt_path::Formatter) -> #fmt_path::Result {
+            fn fmt(&self, #formatter: &mut #fmt_path::Formatter<'_>) -> #fmt_path::Result {
                 #match_self {
                     #body
                 }
@@ -212,7 +212,7 @@ fn format_with(
             struct Dummy #impl_generics (&'_derivative #ty, #phantom_path <(#(#phantom,)*)>) #where_clause;
 
             impl #impl_generics #debug_trait_path for Dummy #ty_generics #where_clause {
-                fn fmt(&self, __f: &mut #fmt_path::Formatter) -> #fmt_path::Result {
+                fn fmt(&self, __f: &mut #fmt_path::Formatter<'_>) -> #fmt_path::Result {
                     #match_self {
                         this => #format_fn(this, __f)
                     }


### PR DESCRIPTION
In the recent nightly, Debug trait's implementation now may need to add <'_>, as hidden lifetime parameters would now become a warning.

And it could be difficult for developers to find out why, as the code of Derivative is not exposed in the compiler's warnings.

```
warning: hidden lifetime parameters in types are deprecated
   --> ff/src/fields/macros.rs:96:9
    |
96  | /         /// Represents an element of the prime field F_p, where `p == P::MODULUS`.
97  | |         /// This type can represent elements in any field of size at most
98  | |         #[doc = $field_size]
99  | |         /// bits.
...   |
114 | |             pub PhantomData<P>,
115 | |         );
    | |__________^ expected named lifetime parameter
```