### PR TITLE
Replace allowing specific lints for derived impls with #[automatically_derived]

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -21,7 +21,7 @@ pub fn derive_copy(input: &ast::Input) -> proc_macro2::TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {
-        #[allow(unused_qualifications)]
+        #[automatically_derived]
         impl #impl_generics #copy_trait_path for #name #ty_generics #where_clause {}
     }
 }
@@ -43,7 +43,7 @@ pub fn derive_clone(input: &ast::Input) -> proc_macro2::TokenStream {
     let is_copy = input.attrs.copy.is_some();
     if is_copy && input.generics.type_params().count() == 0 {
         quote! {
-            #[allow(unused_qualifications)]
+            #[automatically_derived]
             impl #impl_generics #clone_trait_path for #name #ty_generics #where_clause {
                 fn clone(&self) -> Self {
                     *self
@@ -159,7 +159,7 @@ pub fn derive_clone(input: &ast::Input) -> proc_macro2::TokenStream {
         });
 
         quote! {
-            #[allow(unused_qualifications)]
+            #[automatically_derived]
             impl #impl_generics #clone_trait_path for #name #ty_generics #where_clause {
                 fn clone(&self) -> Self {
                     match *self {

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -31,7 +31,7 @@ pub fn derive_eq(input: &ast::Input) -> proc_macro2::TokenStream {
     }
 
     quote! {
-        #[allow(unused_qualifications)]
+        #[automatically_derived]
         impl #impl_generics #eq_trait_path for #name #ty_generics #where_clause {}
     }
 }
@@ -95,8 +95,7 @@ pub fn derive_partial_eq(input: &ast::Input) -> proc_macro2::TokenStream {
     }
 
     quote! {
-        #[allow(unused_qualifications)]
-        #[allow(clippy::unneeded_field_pattern)]
+        #[automatically_derived]
         impl #impl_generics #partial_eq_trait_path for #name #ty_generics #where_clause {
             fn eq(&self, other: &Self) -> bool {
                 #discriminant_cmp && #match_fields
@@ -196,8 +195,7 @@ pub fn derive_partial_ord(
     }
 
     quote! {
-        #[allow(unused_qualifications)]
-        #[allow(clippy::unneeded_field_pattern)]
+        #[automatically_derived]
         impl #impl_generics #partial_ord_trait_path for #name #ty_generics #where_clause {
             fn partial_cmp(&self, other: &Self) -> #option_path<#ordering_path> {
                 match *self {
@@ -293,8 +291,7 @@ pub fn derive_ord(
     }
 
     quote! {
-        #[allow(unused_qualifications)]
-        #[allow(clippy::unneeded_field_pattern)]
+        #[automatically_derived]
         impl #impl_generics #ord_trait_path for #name #ty_generics #where_clause {
             fn cmp(&self, other: &Self) -> #ordering_path {
                 match *self {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -100,8 +100,7 @@ pub fn derive(input: &ast::Input) -> proc_macro2::TokenStream {
     // don't attach a span to prevent issue #58
     let match_self = quote!(match *self);
     quote_spanned! {input.span=>
-        #[allow(unused_qualifications)]
-        #[allow(clippy::unneeded_field_pattern)]
+        #[automatically_derived]
         impl #impl_generics #debug_trait_path for #name #ty_generics #where_clause {
             fn fmt(&self, #formatter: &mut #fmt_path::Formatter) -> #fmt_path::Result {
                 #match_self {

--- a/src/default.rs
+++ b/src/default.rs
@@ -85,7 +85,7 @@ pub fn derive(input: &ast::Input, default: &attr::InputDefault) -> proc_macro2::
 
     let new_fn = if default.new {
         Some(quote!(
-            #[allow(unused_qualifications)]
+            #[automatically_derived]
             impl #impl_generics #name #ty_generics #where_clause {
                 /// Creates a default value for this type.
                 #[inline]
@@ -101,7 +101,7 @@ pub fn derive(input: &ast::Input, default: &attr::InputDefault) -> proc_macro2::
     quote!(
         #new_fn
 
-        #[allow(unused_qualifications)]
+        #[automatically_derived]
         impl #impl_generics #default_trait_path for #name #ty_generics #where_clause {
             fn default() -> Self {
                 #body

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -60,7 +60,7 @@ pub fn derive(input: &ast::Input) -> proc_macro2::TokenStream {
 
     let hasher_ty_parameter = utils::hygienic_type_parameter(input, "__H");
     quote! {
-        #[allow(unused_qualifications)]
+        #[automatically_derived]
         impl #impl_generics #hash_trait_path for #name #ty_generics #where_clause {
             fn hash<#hasher_ty_parameter>(&self, __state: &mut #hasher_ty_parameter)
                 where #hasher_ty_parameter: #hasher_trait_path


### PR DESCRIPTION
Fixes #112 

To test this, one could increase the rust version in the `clippy` job of the `main` workflow. Not sure if that should be part of this pull request.