### PR TITLE
Add `skip_discriminant` to skip discriminant comparison in derived `PartialEq` implementations

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -102,6 +102,8 @@ pub struct InputHash {
 pub struct InputPartialEq {
     /// The `bound` attribute if present and the corresponding bounds.
     bounds: Option<Vec<syn::WherePredicate>>,
+    /// Skip discriminant comparison that happens before equating fields
+    skip_discriminant: bool,
 }
 
 #[derive(Debug, Default)]
@@ -336,6 +338,9 @@ impl Input {
                     for value in values;
                     "bound" => parse_bound(&mut partial_eq.bounds, value, errors),
                     "feature_allow_slow_enum" => (), // backward compatibility, now unnecessary
+                    "skip_discriminant" => {
+                        partial_eq.skip_discriminant = parse_boolean_meta_item(value, true, "skip_discriminant", errors);
+                    }
                 }
             }
             "PartialOrd" => {
@@ -439,6 +444,12 @@ impl Input {
 
     pub fn ord_on_enum(&self) -> bool {
         self.ord.as_ref().map_or(false, |d| d.on_enum)
+    }
+
+    pub(crate) fn skip_discriminant_on_partial_eq(&self) -> bool {
+        self.partial_eq
+            .as_ref()
+            .map_or(false, |d| d.skip_discriminant)
     }
 }
 

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -39,9 +39,13 @@ pub fn derive_eq(input: &ast::Input) -> proc_macro2::TokenStream {
 /// Derive `PartialEq` for `input`.
 pub fn derive_partial_eq(input: &ast::Input) -> proc_macro2::TokenStream {
     let discriminant_cmp = if let ast::Body::Enum(_) = input.body {
-        let discriminant_path = paths::discriminant_path();
+        if !input.attrs.skip_discriminant_on_partial_eq() {
+            let discriminant_path = paths::discriminant_path();
 
-        quote!((#discriminant_path(&*self) == #discriminant_path(&*other)))
+            quote!((#discriminant_path(&*self) == #discriminant_path(&*other)))
+        } else {
+            quote!(true)
+        }
     } else {
         quote!(true)
     };

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -180,7 +180,7 @@ impl<T: Fn (&ast::Field) -> bool> Matcher<T> {
             quote! {
                 match (&#left_matched_expr, &#right_matched_expr) {
                     #t
-                    _ => unreachable!(),
+                    _ => false,
                 }
             }
         }

--- a/tests/derive-debug-generics.rs
+++ b/tests/derive-debug-generics.rs
@@ -88,6 +88,22 @@ fn main() {
     assert_eq!(F(NoDebug).to_show(), "F".to_string());
     assert_eq!(G(42, NoDebug).to_show(), "G(42)".to_string());
     assert_eq!(J(NoDebug).to_show(), "J".to_string());
-    assert_eq!(&format!("{:?}", PhantomField::<NoDebug> { foo: Default::default() }), "PhantomField { foo: PhantomData }");
-    assert_eq!(&format!("{:?}", PhantomTuple::<NoDebug> { foo: Default::default() }), "PhantomTuple { foo: PhantomData }");
+    assert_eq!(
+        &format!(
+            "{:?}",
+            PhantomField::<NoDebug> {
+                foo: Default::default()
+            }
+        ),
+        "PhantomField { foo: PhantomData<derive_debug_generics::NoDebug> }"
+    );
+    assert_eq!(
+        &format!(
+            "{:?}",
+            PhantomTuple::<NoDebug> {
+                foo: Default::default()
+            }
+        ),
+        "PhantomTuple { foo: PhantomData<(derive_debug_generics::NoDebug,)> }"
+    );
 }


### PR DESCRIPTION
rustc wants to use derivative to simplify `PartialEq` derives, but encounters a pretty [significant perf hit](https://github.com/rust-lang/rust/pull/117408#issuecomment-1786120320) because the `derivative(PartialEq)` impl will add a discriminant comparison first, unlike our hand-rolled implementations.

This PR adds a `PartialEq = "skip_discriminant"` mode to skip generating an initial discriminant comparison so that rustc can derive more tailored `PartialEq` implementations for derivative. This is [proven to work](https://github.com/rust-lang/rust/pull/117408#issuecomment-1787702747).